### PR TITLE
Change "Torrust GitHub" to "Powered by Torrust"

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -5,7 +5,7 @@
 <!--        <a class="hover:text-slate-400" href="">Terms of Service</a>-->
 <!--        <p class="sm:ml-4 sm:pl-4 sm:border-l sm:border-slate-200/5"><a class="hover:text-slate-400" href="">Privacy Policy</a></p>-->
 <!--      </div>-->
-      <a class="hover:text-slate-400" href="https://github.com/torrust/torrust">Torrust GitHub</a>
+      <a class="hover:text-slate-400" href="https://github.com/torrust/torrust">Powered by Torrust</a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Changes "Torrust GitHub" in the footer to "Powered by Torrust" which makes it clearer that sites running Torrust are not run by the project.